### PR TITLE
Refactor SHAP plotting and model training utils

### DIFF
--- a/src/eruption_forecast/model/model_evaluator.py
+++ b/src/eruption_forecast/model/model_evaluator.py
@@ -24,7 +24,7 @@ from eruption_forecast.config.constants import (
     THRESHOLD_RESOLUTION,
     PLOT_SEPARATOR_LENGTH,
 )
-from eruption_forecast.plots.shap_plots import plot_shap_summary as _shap
+from eruption_forecast.plots.shap_plots import plot_shap_summary as _plot_shap_summary
 from eruption_forecast.utils.formatting import slugify_class_name
 from eruption_forecast.model.metrics_computer import MetricsComputer
 from eruption_forecast.plots.evaluation_plots import (
@@ -199,7 +199,7 @@ class ModelEvaluator:
         model_path: str,
         X_test: pd.DataFrame | str,
         y_test: pd.Series | str,
-        selected_features: list[str] | None = None,
+        selected_features_path: str | None = None,
         model_name: str = "model",
         output_dir: str | None = None,
     ) -> Self:
@@ -212,8 +212,10 @@ class ModelEvaluator:
             model_path (str): Path to a joblib-saved model file (.pkl).
             X_test (pd.DataFrame | str): Test features DataFrame or path to CSV file.
             y_test (pd.Series | str): True test labels Series or path to CSV file.
-            selected_features (list[str] | None, optional): If provided, filter
-                X_test to these columns. Defaults to None.
+            selected_features_path (str | None, optional): Path to the significant
+                features CSV saved by ModelTrainer (index column contains feature
+                names). If provided, X_test is filtered to those columns before
+                evaluation. Defaults to None.
             model_name (str, optional): Name identifier for the model.
                 Defaults to "model".
             output_dir (str | None, optional): Directory for saved plots.
@@ -230,6 +232,7 @@ class ModelEvaluator:
             ...     model_path="models/xgb_00042.pkl",
             ...     X_test="data/X_test.csv",
             ...     y_test="data/y_test.csv",
+            ...     selected_features_path="data/significant_features_00042.csv",
             ...     model_name="xgb_seed_42",
             ... )
             >>> print(evaluator.summary())
@@ -240,6 +243,12 @@ class ModelEvaluator:
             X_test = pd.read_csv(X_test, index_col=0)
         if isinstance(y_test, str):
             y_test = pd.read_csv(y_test, index_col=0).iloc[:, 0]
+
+        selected_features: list[str] | None = None
+        if selected_features_path is not None:
+            selected_features = (
+                pd.read_csv(selected_features_path, index_col=0).index.tolist()
+            )
 
         return cls(model, X_test, y_test, model_name, output_dir, selected_features)
 
@@ -912,10 +921,9 @@ class ModelEvaluator:
             >>> fig.savefig("custom_shap.png")
         """
 
-        fig = _shap(
+        fig = _plot_shap_summary(
             model=self.model,
             X=self.X_test,
-            feature_names=list(self.X_test.columns),
             max_display=max_display,
             title=f"SHAP Summary — {self.model_name}",
             dpi=dpi,
@@ -958,6 +966,6 @@ class ModelEvaluator:
             "threshold_analysis": self.plot_threshold_analysis(dpi=dpi),
             "feature_importance": self.plot_feature_importance(dpi=dpi),
             "calibration": self.plot_calibration(dpi=dpi),
-            "shap_summary": self.plot_shap_summary(dpi=dpi),
             "prediction_distribution": self.plot_prediction_distribution(dpi=dpi),
+            "shap_summary": self.plot_shap_summary(dpi=dpi),
         }

--- a/src/eruption_forecast/model/model_trainer.py
+++ b/src/eruption_forecast/model/model_trainer.py
@@ -9,7 +9,12 @@ from joblib import Parallel, delayed
 from sklearn.model_selection import GridSearchCV, train_test_split
 
 from eruption_forecast.logger import logger
-from eruption_forecast.utils.ml import load_labels_from_csv, random_under_sampler
+from eruption_forecast.utils.ml import (
+    merge_seed_models,
+    load_labels_from_csv,
+    random_under_sampler,
+    merge_all_classifiers,
+)
 from eruption_forecast.utils.pathutils import resolve_output_dir
 from eruption_forecast.config.constants import (
     TRAIN_TEST_SPLIT,
@@ -687,6 +692,8 @@ class ModelTrainer:
         )
 
         # Save TOP-N significant features
+        # significant_filepath Will be used in ModelEvaluator.from_files(...) method
+        # as selected_features_path paramater
         top_selected_features.to_csv(significant_filepath, index=True)
 
         # Save all SELECTED features if requested
@@ -904,13 +911,11 @@ class ModelTrainer:
 
         return suffix
 
+    @staticmethod
     def _split_and_resample(
-        self,
         X: pd.DataFrame,
         y: pd.Series,
         random_state: int,
-        X_test_filepath: str,
-        y_test_filepath: str,
         sampling_strategy: str | float = 0.75,
     ) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
         """Steps 1-2: stratified train/test split then RandomUnderSampler on train.
@@ -921,8 +926,6 @@ class ModelTrainer:
             X (pd.DataFrame): Full feature matrix.
             y (pd.Series): Full label series.
             random_state (int): Random seed for both split and sampler.
-            X_test_filepath (str): Path to save held-out X_test CSV.
-            y_test_filepath (str): Path to save held-out y_test CSV.
             sampling_strategy (str | float, optional): Under-sampling ratio.
                 Defaults to 0.75.
 
@@ -939,8 +942,6 @@ class ModelTrainer:
             random_state=random_state,
             stratify=y,
         )
-        X_test.to_csv(X_test_filepath)
-        y_test.to_csv(y_test_filepath)
 
         X_train_resampled, y_train_resampled = random_under_sampler(
             features=X_train,
@@ -1119,19 +1120,17 @@ class ModelTrainer:
         logger.info(f"Training Seed: {random_state:05d}")
 
         # ========== STEPS 1-2: Train/Test Split + Resample ==========
-        X_train_resampled, X_test, y_train_resampled, y_test = self._split_and_resample(
+        X_train, X_test, y_train, y_test = self._split_and_resample(
             X=self.df_features,
             y=self.df_labels,
             random_state=random_state,
-            X_test_filepath=X_test_filepath,
-            y_test_filepath=y_test_filepath,
             sampling_strategy=sampling_strategy,
         )
 
         # ========== STEP 3: Feature Selection ==========
         result = self._select_features_for_seed(
-            X_train=X_train_resampled,
-            y_train=y_train_resampled,
+            X_train=X_train,
+            y_train=y_train,
             random_state=random_state,
             significant_filepath=significant_filepath,
             all_features_filepath=all_features_filepath if save_features else None,
@@ -1141,9 +1140,16 @@ class ModelTrainer:
         if result is None:
             return None
 
+        # Save only the significant-feature columns.
+        # X_test_filepath and y_test_filepath will be used as an input
+        # for selected_features_path parameter in ModelEvaluator.from_files(...) method
+        _, top_selected_features, _, _ = result
+        X_test[top_selected_features.index.tolist()].to_csv(X_test_filepath)
+        y_test.to_csv(y_test_filepath)
+
         # ========== STEPS 4-5: CV Training + Evaluation ==========
         metrics = self._cv_train_evaluate(
-            y_train=y_train_resampled,
+            y_train=y_train,
             X_test=X_test,
             y_test=y_test,
             selected_features=result,
@@ -1574,3 +1580,54 @@ class ModelTrainer:
         if self.verbose:
             logger.info(f"Summary metrics saved to: {summary_filepath}")
             logger.info(f"All metrics saved to: {all_metrics_filepath}")
+
+    def merge_models(self, output_path: str | None = None) -> str:
+        """Merge all seed models for this classifier into a single SeedEnsemble pkl.
+
+        Convenience wrapper around
+        :func:`eruption_forecast.utils.ml.merge_seed_models` that uses
+        ``self.csv`` as the registry CSV.  The registry CSV must exist (i.e.
+        ``train()`` or ``train_and_evaluate()`` must have been called first).
+
+        Args:
+            output_path (str | None, optional): Destination path for the merged
+                ``.pkl`` file.  If ``None``, the file is placed alongside the
+                registry CSV as ``merged_model_{suffix}.pkl``.
+                Defaults to ``None``.
+
+        Returns:
+            str: Absolute path to the saved merged ``.pkl`` file.
+
+        Raises:
+            RuntimeError: If no registry CSV is available (training not yet run).
+        """
+        if self.csv is None:
+            raise RuntimeError(
+                "No model registry CSV found. Run train() or "
+                "train_and_evaluate() before calling merge_models()."
+            )
+        return merge_seed_models(self.csv, output_path=output_path)
+
+    @staticmethod
+    def merge_classifier_models(
+        trained_models: dict[str, str],
+        output_path: str | None = None,
+    ) -> str:
+        """Merge multiple classifier registry CSVs into one combined pkl.
+
+        Convenience wrapper around
+        :func:`eruption_forecast.utils.ml.merge_all_classifiers`.  Use this
+        after training multiple classifiers to bundle their ensembles into a
+        single file for ``ModelPredictor``.
+
+        Args:
+            trained_models (dict[str, str]): Mapping of classifier name to
+                the path of its trained-model registry CSV.
+            output_path (str | None, optional): Destination path for the
+                combined ``.pkl`` file.  If ``None``, a default path is derived
+                from the first registry CSV.  Defaults to ``None``.
+
+        Returns:
+            str: Absolute path to the saved combined ``.pkl`` file.
+        """
+        return merge_all_classifiers(trained_models, output_path=output_path)

--- a/src/eruption_forecast/plots/shap_plots.py
+++ b/src/eruption_forecast/plots/shap_plots.py
@@ -27,31 +27,24 @@ if TYPE_CHECKING:
 
 def plot_shap_summary(
     model: BaseEstimator,
-    X: np.ndarray | pd.DataFrame,
-    feature_names: list[str] | None = None,
+    X: pd.DataFrame,
+    selected_features: list[str] | None = None,
     max_display: int = 20,
     title: str | None = None,
     dpi: int = 150,
 ) -> plt.Figure:
     """Plot a SHAP beeswarm summary for a single fitted model.
 
-    Uses ``shap.Explainer`` to auto-select the best explainer (TreeExplainer
-    for tree models, LinearExplainer for linear models, etc.), then renders
-    a beeswarm dot plot showing both direction and magnitude of feature
-    contributions for the top ``max_display`` features.
-
-    When ``X`` is a plain ``np.ndarray`` and ``feature_names`` is provided,
-    ``X`` is wrapped in a ``pd.DataFrame`` so that SHAP axis labels are
-    populated correctly.
+    Renders a beeswarm dot plot showing both direction and magnitude of
+    feature contributions for the top ``max_display`` features. Feature names
+    are read directly from ``X.columns``.
 
     Args:
         model (BaseEstimator): Fitted scikit-learn estimator to explain.
-        X (np.ndarray | pd.DataFrame): Feature matrix used to compute SHAP
-            values. Should be the test set or a representative sample.
-        feature_names (list[str] | None, optional): Feature names for the
-            axis labels. Applied when ``X`` is a plain ``np.ndarray``; ignored
-            when ``X`` is already a ``DataFrame`` (column names are used
-            directly). Defaults to None.
+        X (pd.DataFrame): Feature matrix used to compute SHAP values.
+            Should be the test set or a representative sample.
+        selected_features (list[str] | None, optional): If provided, restrict
+            SHAP computation to these columns only. Defaults to None.
         max_display (int, optional): Maximum number of features to display,
             sorted by mean |SHAP| descending. Defaults to 20.
         title (str | None, optional): Plot title. If None, uses
@@ -65,27 +58,19 @@ def plot_shap_summary(
     Examples:
         >>> from sklearn.ensemble import RandomForestClassifier
         >>> rf = RandomForestClassifier(random_state=0).fit(X_train, y_train)
-        >>> fig = plot_shap_summary(rf, X_test, feature_names=X_test.columns.tolist())
+        >>> fig = plot_shap_summary(rf, X_test)
         >>> fig.savefig("shap_summary.png")
     """
-    # Wrap ndarray with feature names so SHAP labels axes correctly.
-    if feature_names is not None and not isinstance(X, pd.DataFrame):
-        X = pd.DataFrame(X, columns=feature_names)
+    if selected_features is not None:
+        X = X[selected_features]
 
-    # Do not pass X as background masker — shap.Explainer(model, X) fails when
-    # matplotlib rcParams have been customised (shap 0.49 bug). TreeExplainer
-    # does not require background data; X is still used as the evaluation set.
-    explainer = shap.Explainer(model)
-    try:
-        shap_values = explainer(X)
-    except Exception as e:
-        logger.warning(f"SHAP summary plot: {e}")
-        shap_values = explainer(X, check_additivity=False)
-
-    # For binary classifiers shap_values may have shape (n, features, 2);
-    # take the positive-class slice via Explanation indexing.
-    if hasattr(shap_values, "values") and shap_values.values.ndim == 3:  # noqa: PD011
-        shap_values = shap_values[:, :, 1]
+    # Use predict_proba + Independent masker so shap.Explainer works for any
+    # classifier, including XGBClassifier with XGBoost ≥ 3.x where
+    # shap.TreeExplainer fails with a string-to-float conversion error.
+    # The masker is built from X itself (all rows as background).
+    # shap.Explainer(model) without a masker raises "not callable" for some
+    # model types, so the masker is always passed explicitly here.
+    shap_values = _compute_shap_explanation(model, X)
 
     with apply_nature_style():
         # shap.plots.beeswarm always draws on the current figure; capture it
@@ -103,6 +88,68 @@ def plot_shap_summary(
         fig.suptitle(title or "SHAP Summary Plot", y=1.02)
 
     return fig
+
+
+def _compute_shap_explanation(
+    model: Any,
+    X: pd.DataFrame,
+    feature_names: list[str] | None = None,
+) -> shap.Explanation:
+    """Compute a SHAP ``Explanation`` object for the positive class.
+
+    Uses ``shap.Explainer(model.predict_proba, masker)`` with an
+    ``Independent`` masker built from ``X``. This path works for any
+    scikit-learn compatible classifier, including ``XGBClassifier`` with
+    XGBoost ≥ 3.x where ``shap.TreeExplainer`` fails with a string-to-float
+    conversion error, and avoids the "not callable" error raised by
+    ``shap.Explainer(model)`` when no masker is supplied.
+
+    For binary classifiers the explainer returns shape ``(n, features, 2)``;
+    the positive-class slice ``[:, :, 1]`` is taken automatically.
+
+    Args:
+        model (Any): A fitted scikit-learn compatible estimator with a
+            ``predict_proba`` method.
+        X (pd.DataFrame): Feature matrix used as both background masker and
+            evaluation set.
+        feature_names (list[str] | None, optional): Column names used when
+            ``X`` is not a DataFrame. Defaults to None.
+
+    Returns:
+        shap.Explanation: SHAP Explanation object with shape
+        ``(n_samples, n_features)`` for the positive class.
+    """
+    cols = list(X.columns) if isinstance(X, pd.DataFrame) else feature_names
+    masker = shap.maskers.Independent(X, max_samples=len(X))
+    explainer = shap.Explainer(model.predict_proba, masker)
+    shap_output = explainer(X)
+    # Binary classifier: shape (n, features, 2) — take positive-class slice.
+    if shap_output.values.ndim == 3:  # noqa: PD011
+        return shap.Explanation(
+            values=shap_output.values[:, :, 1],  # noqa: PD011
+            data=shap_output.data,
+            feature_names=cols,
+        )
+    return shap_output
+
+
+def _compute_shap_values(model: Any, X: pd.DataFrame) -> np.ndarray:
+    """Compute a 2-D SHAP value array for the positive class.
+
+    Delegates to ``_compute_shap_explanation`` and extracts the raw values
+    array. Returns a plain ``np.ndarray`` of shape ``(n_samples, n_features)``
+    suitable for numerical aggregation.
+
+    Args:
+        model (Any): A fitted scikit-learn compatible estimator.
+        X (pd.DataFrame): Feature matrix used to compute SHAP values.
+
+    Returns:
+        np.ndarray: 2-D array of shape ``(n_samples, n_features)`` containing
+        SHAP values for the positive class.
+    """
+    explanation = _compute_shap_explanation(model, X)
+    return np.asarray(explanation.values)  # noqa: PD011
 
 
 def _extract_shap_array(shap_output: Any) -> np.ndarray:
@@ -214,15 +261,7 @@ def plot_aggregate_shap_summary(
 
     for model, X, seed_names in zip(models, X_tests, per_seed_names, strict=True):
         try:
-            # Do not pass X as background masker — see note in plot_shap_summary.
-            explainer = shap.Explainer(model)
-            try:
-                shap_output = explainer(X)
-            except Exception as e:
-                logger.warning(f"SHAP aggregate summary plot: {e}")
-                shap_output = explainer(X, check_additivity=False)
-
-            vals = _extract_shap_array(shap_output)
+            vals = _compute_shap_values(model, X)
             seed_abs_mean = np.abs(vals).mean(axis=0)  # (n_seed_features,)
 
             # Map seed values into the union feature space

--- a/src/eruption_forecast/utils/ml.py
+++ b/src/eruption_forecast/utils/ml.py
@@ -16,6 +16,8 @@ from imblearn.under_sampling import RandomUnderSampler
 from eruption_forecast.logger import logger
 from eruption_forecast.utils.dataframe import to_series
 from eruption_forecast.config.constants import ERUPTION_PROBABILITY_THRESHOLD
+from eruption_forecast.model.seed_ensemble import SeedEnsemble
+from eruption_forecast.model.classifier_ensemble import ClassifierEnsemble
 
 
 def load_labels_from_csv(label_features_csv: str) -> pd.Series:
@@ -368,3 +370,102 @@ def compute_model_probabilities(
     confidence: np.ndarray = majority_votes / n_seeds
 
     return mean_probability, std_proba, confidence, prediction
+
+
+def merge_seed_models(
+    registry_csv: str,
+    output_path: str | None = None,
+) -> str:
+    """Load all seed models from a registry CSV and bundle into one SeedEnsemble pkl.
+
+    Reads the trained-model registry CSV produced by ``ModelTrainer``, loads
+    every seed estimator and its significant-feature list into memory, and
+    serialises the resulting :class:`~eruption_forecast.model.seed_ensemble.SeedEnsemble`
+    to a single ``.pkl`` file.  This eliminates the per-seed I/O overhead at
+    prediction time.
+
+    Args:
+        registry_csv (str): Path to the trained-model registry CSV (the
+            ``trained_model_{suffix}.csv`` file written by ``ModelTrainer``).
+        output_path (str | None, optional): Destination path for the merged
+            ``.pkl`` file.  If ``None``, the file is written to the same
+            directory as ``registry_csv`` with the name
+            ``merged_model_{suffix}.pkl``, where ``{suffix}`` is derived from
+            the registry CSV filename.  Defaults to ``None``.
+
+    Returns:
+        str: Absolute path to the saved merged ``.pkl`` file.
+
+    Raises:
+        FileNotFoundError: If ``registry_csv`` does not exist.
+    """
+    if output_path is None:
+        registry_dir = os.path.dirname(os.path.abspath(registry_csv))
+        basename = os.path.splitext(os.path.basename(registry_csv))[0]
+        # Replace "trained_model_" prefix with "merged_model_"
+        if basename.startswith("trained_model_"):
+            merged_basename = "merged_model_" + basename[len("trained_model_"):]
+        else:
+            merged_basename = f"merged_{basename}"
+        output_path = os.path.join(registry_dir, f"{merged_basename}.pkl")
+
+    ensemble = SeedEnsemble.from_registry(registry_csv)
+    ensemble.save(output_path)
+    return output_path
+
+
+def merge_all_classifiers(
+    trained_models: dict[str, str],
+    output_path: str | None = None,
+) -> str:
+    """Merge multiple classifier registry CSVs into a single multi-classifier pkl.
+
+    Calls :func:`merge_seed_models` for each classifier, bundles the resulting
+    :class:`~eruption_forecast.model.seed_ensemble.SeedEnsemble` objects into a
+    plain ``dict[str, SeedEnsemble]``, and serialises the dict to one ``.pkl``
+    file.  ``ModelPredictor`` detects this dict type automatically when the path
+    is passed as the ``trained_models`` parameter.
+
+    Args:
+        trained_models (dict[str, str]): Mapping of classifier name to the path
+            of its trained-model registry CSV (e.g.
+            ``{"rf": "path/to/rf_registry.csv", "xgb": "path/to/xgb_registry.csv"}``).
+        output_path (str | None, optional): Destination path for the combined
+            ``.pkl`` file.  If ``None``, the file is placed one directory above
+            the first registry CSV (i.e. in the ``trainings/`` root) and named
+            ``merged_classifiers_{suffix}.pkl``, where ``{suffix}`` is derived
+            from the first registry CSV filename.  Defaults to ``None``.
+
+    Returns:
+        str: Absolute path to the saved combined ``.pkl`` file.
+
+    Raises:
+        ValueError: If ``trained_models`` is empty.
+        FileNotFoundError: If any registry CSV does not exist.
+    """
+    if not trained_models:
+        raise ValueError("trained_models must not be empty.")
+
+    if output_path is None:
+        first_csv = next(iter(trained_models.values()))
+        # Go one level up from the classifier dir to the trainings root
+        trainings_dir = os.path.dirname(
+            os.path.dirname(os.path.abspath(first_csv))
+        )
+        basename = os.path.splitext(os.path.basename(first_csv))[0]
+        if basename.startswith("trained_model_"):
+            suffix = basename[len("trained_model_"):]
+        else:
+            suffix = basename
+        output_path = os.path.join(
+            trainings_dir, f"merged_classifiers_{suffix}.pkl"
+        )
+
+    ensembles: dict[str, SeedEnsemble] = {}
+    for name, csv_path in trained_models.items():
+        logger.info(f"[merge_all_classifiers] Merging classifier: {name}")
+        ensembles[name] = SeedEnsemble.from_registry(csv_path)
+
+    classifier_ensemble = ClassifierEnsemble.from_seed_ensembles(ensembles)
+    classifier_ensemble.save(output_path)
+    return output_path


### PR DESCRIPTION
- Refactor plot_shap_summary to accept DataFrame + selected_features and compute SHAP via an Independent masker + model.predict_proba. Add _compute_shap_explanation and _compute_shap_values to handle binary-class slicing and avoid shap.Explainer/model compatibility issues (e.g. XGBoost ≥3.x).
- Update ModelEvaluator to accept selected_features_path (CSV) instead of a list, load the feature list when provided, and call the renamed plot_shap_summary import.
- Change ModelTrainer internals: make _split_and_resample static, remove file-writing from the splitter, save significant-feature CSV earlier, write a filtered X_test (only significant features) and y_test for evaluator use, and adjust feature-selection/training callsites accordingly.
- Add utilities merge_seed_models and merge_all_classifiers in utils.ml and expose wrapper methods (merge_models, merge_classifier_models) on ModelTrainer to produce merged SeedEnsemble/ClassifierEnsemble pickles for faster prediction workloads.

These changes improve SHAP compatibility across model types, streamline use of saved significant features during evaluation, and add conveniences for bundling seed/classifier ensembles.