### PR TITLE
Defer date handling; add label builder & validation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,12 +6,10 @@ version: '1.0'
 model:
   station: OJN             # Station code (e.g. OJN, MEPAS)
   channel: EHZ             # Channel code (e.g. EHZ, BHZ)
-  start_date: '2025-03-16' # Start date of the full dataset (YYYY-MM-DD)
-  end_date: '2025-03-22'   # End date of the full dataset (YYYY-MM-DD)
   window_size: 1            # Sliding window size in days
   volcano_id: MERAPI        # Volcano identifier used in label filenames
-  network: VG               # SEED network code
-  location: '00'            # SEED location code
+  network: VG               # SEED network code (required – no default)
+  location: '00'            # SEED location code (required – no default)
   output_dir: null          # Override default output directory (null = auto)
   root_dir: null            # Root directory anchor for relative output paths (null = cwd)
   overwrite: false          # Overwrite existing output files
@@ -20,6 +18,8 @@ model:
   debug: false
 
 calculate:
+  start_date: '2025-03-16'  # Start date for tremor calculation (YYYY-MM-DD)
+  end_date: '2025-03-22'    # End date for tremor calculation (YYYY-MM-DD)
   source: sds               # Data source: 'sds' or 'fdsn'
   sds_dir: D:/Data/OJN      # Path to SDS archive root (required when source='sds')
   methods: null             # Tremor methods to compute (null = all: rsam + dsar)
@@ -55,7 +55,7 @@ extract_features:
   select_tremor_columns:    # Tremor columns to use for feature extraction
     - rsam_f2
     - rsam_f3
-  save_tremor_matrix_per_method: false  # Save a separate tremor matrix per tremor column
+  save_tremor_matrix_per_method: true   # Save a separate tremor matrix per tremor column
   save_tremor_matrix_per_id: false      # Save a separate tremor matrix per window id
   exclude_features: null    # tsfresh feature names to exclude (null = none)
   use_relevant_features: false          # Use only statistically relevant features (tsfresh FDR)
@@ -89,6 +89,7 @@ forecast:
   window_step: 12           # Step between forecast windows
   window_step_unit: hours   # Unit for window_step: 'minutes' or 'hours'
   save_predictions: true    # Save prediction CSV to disk
+  threshold: 0.5            # Probability threshold for classifying a window as eruption
   save_plot: true           # Save forecast probability plot
   n_jobs: null              # Workers for feature extraction during forecast (null = model.n_jobs)
   overwrite: false

--- a/src/eruption_forecast/config/pipeline_config.py
+++ b/src/eruption_forecast/config/pipeline_config.py
@@ -61,12 +61,10 @@ class ModelConfig(_ConfigBase):
     Attributes:
         station (str): Seismic station code (e.g. ``"OJN"``). Defaults to ``""``.
         channel (str): Seismic channel code (e.g. ``"EHZ"``). Defaults to ``""``.
-        start_date (str): Pipeline start date in ``"YYYY-MM-DD"`` format. Defaults to ``""``.
-        end_date (str): Pipeline end date in ``"YYYY-MM-DD"`` format. Defaults to ``""``.
         window_size (int): Duration in days of each tremor window. Defaults to ``1``.
         volcano_id (str): Unique volcano identifier used in output filenames. Defaults to ``""``.
-        network (str): Seismic network code. Defaults to ``"VG"``.
-        location (str): Seismic location code. Defaults to ``"00"``.
+        network (str): Seismic network code. Defaults to ``""``.
+        location (str): Seismic location code. Defaults to ``""``.
         output_dir (str | None): Base output directory. ``None`` resolves to
             ``root_dir/output``. Defaults to ``None``.
         root_dir (str | None): Anchor directory for resolving relative paths.
@@ -79,12 +77,10 @@ class ModelConfig(_ConfigBase):
 
     station: str = ""
     channel: str = ""
-    start_date: str = ""
-    end_date: str = ""
     window_size: int = 1
     volcano_id: str = ""
-    network: str = "VG"
-    location: str = "00"
+    network: str = ""
+    location: str = ""
     output_dir: str | None = None
     root_dir: str | None = None
     overwrite: bool = False
@@ -101,6 +97,10 @@ class CalculateConfig(_ConfigBase):
     calculation step can be replayed identically.
 
     Attributes:
+        start_date (str): Tremor calculation start date in ``"YYYY-MM-DD"`` format.
+            Defaults to ``""``.
+        end_date (str): Tremor calculation end date in ``"YYYY-MM-DD"`` format.
+            Defaults to ``""``.
         source (str): Seismic data source — ``"sds"`` or ``"fdsn"``. Defaults to ``"sds"``.
         sds_dir (str | None): Path to the SDS archive directory. Required when
             ``source="sds"``. Defaults to ``None``.
@@ -132,6 +132,8 @@ class CalculateConfig(_ConfigBase):
         debug (bool): Enable debug-level logging. Defaults to ``False``.
     """
 
+    start_date: str = ""
+    end_date: str = ""
     source: str = "sds"
     sds_dir: str | None = None
     methods: list[str] | None = None

--- a/src/eruption_forecast/features/features_builder.py
+++ b/src/eruption_forecast/features/features_builder.py
@@ -2,6 +2,7 @@ import os
 from typing import Any
 
 import pandas as pd
+from cycler import V
 from tsfresh import (
     extract_features as tsfresh_extract_features,
     extract_relevant_features,
@@ -427,11 +428,11 @@ class FeaturesBuilder:
 
             df = df[df["id"].isin(y_series.index)]
 
-            # Ensure tremor unified IDs has the sama ID with y_series
+            # Ensure tremor unified IDs match the IDs in y_series
             length_unique_id = len(df["id"].unique())
             if len(y_series.index) != length_unique_id:
                 error_message = (
-                    "IDs in tremor matrix unified is not the samw with ID from labels."
+                    "IDs in tremor matrix are not the same as IDs from labels."
                 )
                 logger.error(error_message)
                 raise ValueError(error_message)
@@ -557,6 +558,9 @@ class FeaturesBuilder:
         )
         label_df.to_csv(label_csv, index=True)
         self.label_features_csv = label_csv
+
+        if self.verbose:
+            logger.info(f"Label features CSV saved at {label_csv}")
 
         return dates_str, label_df
 

--- a/src/eruption_forecast/features/tremor_matrix_builder.py
+++ b/src/eruption_forecast/features/tremor_matrix_builder.py
@@ -488,9 +488,19 @@ class TremorMatrixBuilder:
         if not self.overwrite and (os.path.isfile(tremor_matrix_csv)):
             if verbose:
                 logger.info(f"Tremor matrix {tremor_matrix_csv} already exists.")
-            self.df = pd.read_csv(tremor_matrix_csv)
-            self.csv = tremor_matrix_csv
-            return self
+            df = pd.read_csv(tremor_matrix_csv)
+            columns = df.columns.tolist()
+
+            # Ensure select_tremor_columns exists in tremor matrix column
+            if select_tremor_columns is None or all(
+                item in columns for item in select_tremor_columns
+            ):
+                self.df = df
+                self.csv = tremor_matrix_csv
+                return self
+
+            if verbose:
+                logger.warning("Cannot skip, because there is column(s) different.")
 
         if verbose:
             logger.info("Create tremor matrix which grouped by label ID.")

--- a/src/eruption_forecast/label/label_builder.py
+++ b/src/eruption_forecast/label/label_builder.py
@@ -506,17 +506,16 @@ class LabelBuilder:
                 # Move the start of eruption to number of day_to_forecast
                 start_eruption = day_of_eruption - timedelta(days=self.day_to_forecast)
 
-                # Set start time of eruption to 00:00:00
-                start_eruption = start_eruption.replace(hour=0, minute=0, second=0)
-
-                # Set end time of eruption to at 23:59:59
-                end_eruption = day_of_eruption.replace(hour=23, minute=59, second=59)
+                # Set start time of eruption to 00:00:00 and end time of eruption to at 23:59:59
+                start_eruption, end_eruption, _start_eruption_str, end_eruption_str = (
+                    normalize_dates(start_eruption, day_of_eruption)
+                )
 
                 # Stop if eruption date is beyond the end date
                 if end_eruption > self.end_date:
                     if self.debug:
                         logger.debug(
-                            f"Eruption date {eruption} is beyond end date {self.end_date_str}, skipping"
+                            f"Eruption date {end_eruption_str} is beyond end date {self.end_date_str}, skipping"
                         )
                     continue
 

--- a/src/eruption_forecast/model/forecast_model.py
+++ b/src/eruption_forecast/model/forecast_model.py
@@ -27,11 +27,11 @@ from eruption_forecast.config.pipeline_config import (
     BuildLabelConfig,
     ExtractFeaturesConfig,
 )
+from eruption_forecast.report.pipeline_report import PipelineReport
 from eruption_forecast.tremor.calculate_tremor import CalculateTremor
 from eruption_forecast.features.features_builder import FeaturesBuilder
 from eruption_forecast.label.dynamic_label_builder import DynamicLabelBuilder
 from eruption_forecast.features.tremor_matrix_builder import TremorMatrixBuilder
-from eruption_forecast.report.pipeline_report import PipelineReport
 
 
 class ForecastModel:
@@ -427,7 +427,7 @@ class ForecastModel:
         if self.start_date_minus_window_size is None:
             raise ValueError("self.start_date_minus_window_size cannot be None")
         if self.end_date is None:
-            raise ValueError("self.start_date_minus_window_size cannot be None")
+            raise ValueError("self.end_date cannot be None")
 
         # Create CalculateTremor with explicit parameters for type safety
         calculate = CalculateTremor(
@@ -530,7 +530,7 @@ class ForecastModel:
             if self.verbose:
                 logger.info(
                     f"start_date parameter: {self.start_date_minus_window_size} updated to "
-                    f"tremor start date: {tremor_data.start_date}"
+                    f"tremor start date: {self.start_date_str}"
                 )
 
         # Adjust end date if later than tremor end
@@ -540,7 +540,7 @@ class ForecastModel:
             if self.verbose:
                 logger.info(
                     f"end_date parameter: {self.end_date} updated to "
-                    f"tremor end date: {tremor_data.end_date}"
+                    f"tremor end date: {self.end_date_str}"
                 )
 
     @staticmethod
@@ -730,7 +730,10 @@ class ForecastModel:
 
         Returns:
             Self: ForecastModel instance for method chaining.
-                Sets self.tremor_data, self.TremorData, and self.tremor_csv.
+                Sets ``self.tremor_data``, ``self.TremorData``, ``self.tremor_csv``,
+                ``self.start_date``, ``self.end_date``, ``self.start_date_str``,
+                ``self.end_date_str``, and ``self.start_date_minus_window_size``
+                from the loaded tremor DataFrame's datetime index.
 
         Example:
             >>> model = ForecastModel(
@@ -749,6 +752,15 @@ class ForecastModel:
         self.tremor_data = tremor_data.from_csv(tremor_csv)
         self.TremorData.csv = tremor_csv
         self.tremor_csv = tremor_csv
+
+        self.start_date = self.tremor_data.index[0].to_pydatetime()
+        self.end_date = self.tremor_data.index[-1].to_pydatetime()
+        self.start_date_str = self.start_date.strftime("%Y-%m-%d")
+        self.end_date_str = self.end_date.strftime("%Y-%m-%d")
+        self.start_date_minus_window_size = self.start_date - timedelta(
+            days=self.window_size
+        )
+
         return self
 
     def calculate(
@@ -1026,7 +1038,7 @@ class ForecastModel:
                 )
             label_builder = DynamicLabelBuilder(
                 days_before_eruption=days_before_eruption,
-                **label_kwargs,  # ty:ignore[invalid-argument-type]
+                **label_kwargs,
             ).build()
 
             return label_builder
@@ -1046,7 +1058,7 @@ class ForecastModel:
         label_builder = LabelBuilder(
             start_date=to_datetime(train_start_date),
             end_date=to_datetime(train_end_date),
-            **label_kwargs,  # ty:ignore[invalid-argument-type]
+            **label_kwargs,
         ).build()
 
         return label_builder

--- a/src/eruption_forecast/model/forecast_model.py
+++ b/src/eruption_forecast/model/forecast_model.py
@@ -832,7 +832,7 @@ class ForecastModel:
         self.end_date_str = _end_str
         self.start_date_minus_window_size = _start - timedelta(days=self.window_size)
 
-        if self.verbose:
+        if verbose or self.verbose:
             logger.info(f"Start Date: {_start_str}")
             logger.info(f"End Date: {_end_str}")
 
@@ -1162,8 +1162,8 @@ class ForecastModel:
         self.basename = os.path.basename(label_builder.csv).split(".csv")[0]
 
         # Filter labels from start_date onwards
-        if builder == "standard":
-            df_label = df_label.loc[self.start_date :]
+        if builder == "standard" and train_start_date is not None:
+            df_label = df_label.loc[train_start_date :]
 
         if df_label.empty:
             raise ValueError(f"Label from start date {self.start_date} is empty.")

--- a/src/eruption_forecast/model/forecast_model.py
+++ b/src/eruption_forecast/model/forecast_model.py
@@ -31,6 +31,7 @@ from eruption_forecast.tremor.calculate_tremor import CalculateTremor
 from eruption_forecast.features.features_builder import FeaturesBuilder
 from eruption_forecast.label.dynamic_label_builder import DynamicLabelBuilder
 from eruption_forecast.features.tremor_matrix_builder import TremorMatrixBuilder
+from eruption_forecast.report.pipeline_report import PipelineReport
 
 
 class ForecastModel:
@@ -51,8 +52,8 @@ class ForecastModel:
     Attributes:
         station (str): Seismic station code.
         channel (str): Seismic channel code.
-        start_date (datetime): Pipeline start date.
-        end_date (datetime): Pipeline end date.
+        start_date (datetime | None): Tremor calculation start date; set by ``calculate()``.
+        end_date (datetime | None): Tremor calculation end date; set by ``calculate()``.
         window_size (int): Window size in days for training data windows.
         volcano_id (str): Volcano identifier for output naming.
         network (str): Seismic network code.
@@ -100,12 +101,10 @@ class ForecastModel:
     Args:
         station (str): Seismic station code (e.g., "OJN").
         channel (str): Seismic channel code (e.g., "EHZ").
-        start_date (str | datetime): Start date in YYYY-MM-DD format.
-        end_date (str | datetime): End date in YYYY-MM-DD format.
         window_size (int): Window size in days for training data windows.
         volcano_id (str): Volcano identifier for output naming.
-        network (str, optional): Seismic network code. Defaults to "VG".
-        location (str, optional): Seismic location code. Defaults to "00".
+        network (str): Seismic network code (e.g., "VG").
+        location (str): Seismic location code (e.g., "00").
         output_dir (str | None, optional): Directory for output files. If None,
             defaults to ``root_dir/output``. Relative paths are resolved against
             ``root_dir`` (or ``os.getcwd()`` when ``root_dir`` is None). Absolute
@@ -121,20 +120,25 @@ class ForecastModel:
         debug (bool, optional): If True, enables debug mode. Defaults to False.
 
     Raises:
-        ValueError: If start_date >= end_date or window_size < 1.
+        ValueError: If window_size < 1 or network/location are empty.
 
     Examples:
         >>> # Complete pipeline example
         >>> model = ForecastModel(
         ...     station="OJN",
         ...     channel="EHZ",
-        ...     start_date="2024-01-01",
-        ...     end_date="2024-06-30",
         ...     window_size=1,
         ...     volcano_id="LEWOTOBI",
+        ...     network="VG",
+        ...     location="00",
         ...     root_dir=r"D:\\Projects\\eruption-forecast",
         ... )
-        >>> model.calculate(source="sds", sds_dir="data/sds")
+        >>> model.calculate(
+        ...     start_date="2024-01-01",
+        ...     end_date="2024-06-30",
+        ...     source="sds",
+        ...     sds_dir="data/sds",
+        ... )
         >>> model.build_label(
         ...     window_step=12,
         ...     window_step_unit="hours",
@@ -152,12 +156,10 @@ class ForecastModel:
         self,
         station: str,
         channel: str,
-        start_date: str | datetime,
-        end_date: str | datetime,
+        network: str,
+        location: str,
         window_size: int,
         volcano_id: str,
-        network: str = "VG",
-        location: str = "00",
         output_dir: str | None = None,
         root_dir: str | None = None,
         overwrite: bool = False,
@@ -167,22 +169,19 @@ class ForecastModel:
     ) -> None:
         """Initialize the ForecastModel pipeline orchestrator.
 
-        Normalises dates, resolves all output directory paths, and initialises
-        lifecycle state attributes. No data is loaded or processed until the
-        pipeline stage methods (calculate, build_label, extract_features, train,
-        forecast) are called.
+        Resolves all output directory paths and initialises lifecycle state
+        attributes. Dates are not required at construction time — pass them to
+        ``calculate()`` when fetching tremor data. No data is loaded or
+        processed until the pipeline stage methods (calculate, build_label,
+        extract_features, train, forecast) are called.
 
         Args:
             station (str): Seismic station code (e.g., "OJN").
             channel (str): Channel code (e.g., "EHZ").
-            start_date (str | datetime): Start date for the analysis period in
-                "YYYY-MM-DD" format or as a datetime object.
-            end_date (str | datetime): End date for the analysis period in
-                "YYYY-MM-DD" format or as a datetime object.
+            network (str): Seismic network code (e.g., "VG").
+            location (str): Location code (e.g., "00").
             window_size (int): Window size in days used for matrix building and forecasting.
             volcano_id (str): Unique volcano identifier used for labelling.
-            network (str, optional): Seismic network code. Defaults to "VG".
-            location (str, optional): Location code. Defaults to "00".
             output_dir (str | None, optional): Base output directory. Defaults to None
                 (resolved from root_dir or os.getcwd()).
             root_dir (str | None, optional): Root project directory used to anchor
@@ -196,11 +195,6 @@ class ForecastModel:
         # ------------------------------------------------------------------
         # Set DEFAULT parameter
         # ------------------------------------------------------------------
-        start_date, end_date, start_date_str, end_date_str = normalize_dates(
-            start_date, end_date
-        )
-        network = network or "VG"
-        location = location or "00"
         root_dir = os.path.abspath(root_dir) if root_dir is not None else None
         nslc, output_dir, station_dir, features_dir = self._setup_directories(
             network, station, location, channel, output_dir, root_dir
@@ -211,8 +205,6 @@ class ForecastModel:
         # ------------------------------------------------------------------
         self.station = station
         self.channel = channel
-        self.start_date: datetime = start_date
-        self.end_date: datetime = end_date
         self.window_size: int = window_size
         self.volcano_id = volcano_id
         self.network = network
@@ -227,9 +219,11 @@ class ForecastModel:
         # ------------------------------------------------------------------
         # Set ADDITIONAL properties (derived values)
         # ------------------------------------------------------------------
-        self.start_date_minus_window_size = start_date - timedelta(days=window_size)
-        self.start_date_str = start_date_str
-        self.end_date_str = end_date_str
+        self.start_date: datetime | None = None
+        self.end_date: datetime | None = None
+        self.start_date_minus_window_size: datetime | None = None
+        self.start_date_str: str | None = None
+        self.end_date_str: str | None = None
         self.nslc = nslc
         self.station_dir = station_dir
         self.features_dir = features_dir
@@ -295,8 +289,6 @@ class ForecastModel:
             model=ModelConfig(
                 station=station,
                 channel=channel,
-                start_date=start_date_str,
-                end_date=end_date_str,
                 window_size=window_size,
                 volcano_id=volcano_id,
                 network=network,
@@ -325,8 +317,6 @@ class ForecastModel:
             logger.info("⚠️ Forecast Model :: Debug mode is ON")
 
         if verbose:
-            logger.info(f"Start Date: {start_date_str}")
-            logger.info(f"End Date: {end_date_str}")
             logger.info(f"Volcano ID: {self.volcano_id}")
             logger.info(f"NSLC: {self.nslc}")
             logger.info(f"Output Dir: {self.output_dir}")
@@ -407,7 +397,7 @@ class ForecastModel:
             plot_daily (bool): Whether to plot daily results.
             save_plot (bool): Whether to save plots to disk.
             overwrite_plot (bool): Whether to overwrite existing plots.
-            remove_tremor_anomalies (bool, optional): Remove anomalies after tremor calciulated.
+            remove_tremor_anomalies (bool, optional): Remove anomalies after tremor calculated.
                 Using Z-score analysis to determine the anomalies. Defaults to False.
             n_jobs (int | None, optional): Number of jobs to run in parallel.
                 Isolated to this method only. If None, uses ``self.n_jobs``.
@@ -433,6 +423,11 @@ class ForecastModel:
         """
         verbose = verbose or self.verbose
         debug = debug or self.debug
+
+        if self.start_date_minus_window_size is None:
+            raise ValueError("self.start_date_minus_window_size cannot be None")
+        if self.end_date is None:
+            raise ValueError("self.start_date_minus_window_size cannot be None")
 
         # Create CalculateTremor with explicit parameters for type safety
         calculate = CalculateTremor(
@@ -526,7 +521,10 @@ class ForecastModel:
             tremor_data (TremorData): Loaded tremor data wrapper with date range info.
         """
         # Adjust start date if earlier than tremor start
-        if self.start_date_minus_window_size < tremor_data.start_date:
+        if (
+            isinstance(self.start_date_minus_window_size, datetime)
+            and self.start_date_minus_window_size < tremor_data.start_date
+        ):
             self.start_date = tremor_data.start_date
             self.start_date_str = tremor_data.start_date_str
             if self.verbose:
@@ -536,7 +534,7 @@ class ForecastModel:
                 )
 
         # Adjust end date if later than tremor end
-        if self.end_date > tremor_data.end_date:
+        if isinstance(self.end_date, datetime) and self.end_date > tremor_data.end_date:
             self.end_date = tremor_data.end_date
             self.end_date_str = tremor_data.end_date_str
             if self.verbose:
@@ -667,14 +665,13 @@ class ForecastModel:
     def validate(self) -> None:
         """Validate initialization parameters.
 
-        Ensures that window_size is positive, date ranges are valid,
-        and required string parameters (station, channel, volcano_id)
-        are not empty.
+        Ensures that window_size is positive and required string parameters
+        (station, channel, volcano_id, network, location) are not empty.
+        Date range validation is deferred to ``calculate()``.
 
         Raises:
-            ValueError: If window_size is <= 0, date ranges are invalid
-                (start_date >= end_date), or required string parameters
-                (station, channel, volcano_id) are empty.
+            ValueError: If window_size is <= 0, or required string parameters
+                (station, channel, volcano_id, network, location) are empty.
 
         Example:
             >>> model = ForecastModel(...)
@@ -686,9 +683,6 @@ class ForecastModel:
                 f"window_size must be greater than 0. Got: {self.window_size}"
             )
 
-        # Validate date ranges
-        validate_date_ranges(self.start_date, self.end_date)
-
         # Validate strings are not empty
         if not self.station.strip():
             raise ValueError("station cannot be empty")
@@ -698,6 +692,15 @@ class ForecastModel:
 
         if not self.volcano_id.strip():
             raise ValueError("volcano_id cannot be empty")
+
+        if not self.network.strip():
+            raise ValueError("network cannot be empty")
+
+        if not self.location.strip():
+            raise ValueError("location cannot be empty")
+
+        if self.n_jobs <= 0:
+            raise ValueError(f"n_jobs must be greater than 0. Got: {self.n_jobs}")
 
     def create_directories(self) -> None:
         """Create required output directory structure.
@@ -750,6 +753,8 @@ class ForecastModel:
 
     def calculate(
         self,
+        start_date: str | datetime,
+        end_date: str | datetime,
         source: Literal["sds", "fdsn"] = "sds",
         methods: list[str] | None = None,
         filename_prefix: str | None = None,
@@ -775,12 +780,16 @@ class ForecastModel:
         the pipeline date range is clipped to the available data.
 
         Args:
+            start_date (str | datetime): Start date for the tremor calculation period
+                in "YYYY-MM-DD" format or as a datetime object.
+            end_date (str | datetime): End date for the tremor calculation period
+                in "YYYY-MM-DD" format or as a datetime object.
             source (Literal["sds", "fdsn"]): Seismic data source. Defaults to "sds".
             methods (list[str] | None): Calculation methods to apply. Defaults to None.
             filename_prefix (str | None): Prefix for generated filenames. Defaults to None.
             remove_outlier_method (Literal["all", "maximum"]): Outlier removal method.
                 Defaults to "maximum".
-            remove_tremor_anomalies (bool, optional): Remove anomalies after tremor calciulated.
+            remove_tremor_anomalies (bool, optional): Remove anomalies after tremor calculated.
                 Using Z-score analysis to determine the anomalies. Defaults to False.
             interpolate (bool): If True, interpolates gaps in the data. Defaults to True.
             value_multiplier (float | None): Scaling factor for seismic values. Defaults to None.
@@ -802,6 +811,19 @@ class ForecastModel:
         Returns:
             Self: ForecastModel instance for method chaining.
         """
+        # Normalise and store dates on self
+        _start, _end, _start_str, _end_str = normalize_dates(start_date, end_date)
+        validate_date_ranges(_start, _end)
+        self.start_date = _start
+        self.end_date = _end
+        self.start_date_str = _start_str
+        self.end_date_str = _end_str
+        self.start_date_minus_window_size = _start - timedelta(days=self.window_size)
+
+        if self.verbose:
+            logger.info(f"Start Date: {_start_str}")
+            logger.info(f"End Date: {_end_str}")
+
         # Setup CalculateTremor instance
         calculate = self._setup_calculate_tremor(
             methods=methods,
@@ -842,6 +864,8 @@ class ForecastModel:
         self.tremor_data = tremor_data.df.loc[self.start_date : self.end_date]
 
         self._config.calculate = CalculateConfig(
+            start_date=_start_str,
+            end_date=_end_str,
             source=source,
             sds_dir=sds_dir,
             methods=methods,
@@ -958,6 +982,75 @@ class ForecastModel:
 
         return self
 
+    @staticmethod
+    def _label_builder(
+        builder: Literal["standard", "dynamic"],
+        label_kwargs: dict[str, Any],
+        days_before_eruption: int | None = None,
+        train_start_date: str | datetime | None = None,
+        train_end_date: str | datetime | None = None,
+    ) -> LabelBuilder:
+        """Instantiate and build a label builder of the requested type.
+
+        Dispatches to either ``DynamicLabelBuilder`` (one window per eruption)
+        or ``LabelBuilder`` (one global window spanning the full date range)
+        based on the ``builder`` argument, then calls ``.build()`` and returns
+        the resulting instance.
+
+        Args:
+            builder (Literal["standard", "dynamic"]): Label builder variant.
+                ``"standard"`` uses a single global window; ``"dynamic"``
+                generates one window per eruption event.
+            label_kwargs (dict[str, Any]): Shared keyword arguments forwarded
+                to the builder constructor (e.g. window_step, eruption_dates).
+            days_before_eruption (int | None): Days before each eruption to
+                start its window. Required when ``builder="dynamic"``.
+                Defaults to None.
+            train_start_date (str | datetime | None): Label window start date.
+                Required when ``builder="standard"``. Defaults to None.
+            train_end_date (str | datetime | None): Label window end date.
+                Required when ``builder="standard"``. Defaults to None.
+
+        Returns:
+            LabelBuilder: A fully built label builder instance.
+
+        Raises:
+            ValueError: If ``builder="dynamic"`` and ``days_before_eruption``
+                is None, or if ``builder="standard"`` and either
+                ``train_start_date`` or ``train_end_date`` is None.
+        """
+        if builder == "dynamic":
+            if days_before_eruption is None:
+                raise ValueError(
+                    "days_before_eruption is required when builder='dynamic'."
+                )
+            label_builder = DynamicLabelBuilder(
+                days_before_eruption=days_before_eruption,
+                **label_kwargs,  # ty:ignore[invalid-argument-type]
+            ).build()
+
+            return label_builder
+
+        if train_start_date is None:
+            raise ValueError(
+                "start_date is required for builder='standard'. "
+                "Either call calculate() first or pass start_date explicitly."
+            )
+        if train_end_date is None:
+            raise ValueError(
+                "end_date is required for builder='standard'. "
+                "Either call calculate() first or pass end_date explicitly."
+            )
+
+        validate_date_ranges(train_start_date, train_end_date)
+        label_builder = LabelBuilder(
+            start_date=to_datetime(train_start_date),
+            end_date=to_datetime(train_end_date),
+            **label_kwargs,  # ty:ignore[invalid-argument-type]
+        ).build()
+
+        return label_builder
+
     def build_label(
         self,
         window_step: int,
@@ -1036,22 +1129,13 @@ class ForecastModel:
         }
 
         # Build labels
-        if builder == "dynamic":
-            if days_before_eruption is None:
-                raise ValueError(
-                    "days_before_eruption is required when builder='dynamic'."
-                )
-            label_builder = DynamicLabelBuilder(
-                days_before_eruption=days_before_eruption,
-                **label_kwargs,  # ty:ignore[invalid-argument-type]
-            ).build()
-        else:
-            validate_date_ranges(train_start_date, train_end_date)
-            label_builder = LabelBuilder(
-                start_date=to_datetime(train_start_date),
-                end_date=to_datetime(train_end_date),
-                **label_kwargs,  # ty:ignore[invalid-argument-type]
-            ).build()
+        label_builder = self._label_builder(
+            builder=builder,
+            label_kwargs=label_kwargs,
+            days_before_eruption=days_before_eruption,
+            train_start_date=train_start_date,
+            train_end_date=train_end_date,
+        )
 
         # Prepare tremor data
         df_tremor = self._prepare_tremor_for_labeling(tremor_columns)
@@ -1066,7 +1150,7 @@ class ForecastModel:
         self.basename = os.path.basename(label_builder.csv).split(".csv")[0]
 
         # Filter labels from start_date onwards
-        if builder == "standart":
+        if builder == "standard":
             df_label = df_label.loc[self.start_date :]
 
         if df_label.empty:
@@ -1277,7 +1361,7 @@ class ForecastModel:
                 backend handles nested parallelism without deadlocks. Combine with
                 ``n_jobs`` to control the total CPU budget:
                 ``n_jobs × grid_search_n_jobs ≤ total_cores``. Defaults to 1.
-            plot_shap (bool, optioonal): Plot SHAP explanation value. Defaults to False.
+            plot_shap (bool, optional): Plot SHAP explanation value. Defaults to False.
             overwrite (bool, optional): Whether to overwrite existing files. Defaults to False.
             verbose (bool, optional): Whether to enable verbose mode. Defaults to False.
             save_model (bool, optional): If True, serialises the full ``ForecastModel``
@@ -1317,7 +1401,7 @@ class ForecastModel:
                 logger.info("|- Label is empty. Model evaluation will be set to False.")
                 with_evaluation = False
             if not with_evaluation:
-                logger.info("|- Training for predcition.")
+                logger.info("|- Training for prediction.")
             logger.info("=" * 50)
 
         features_csv = extracted_features_csv or self.features_csv
@@ -1678,8 +1762,6 @@ class ForecastModel:
             >>> fm.calculate(...).build_label(...).train(...).generate_report()
             >>> fm.generate_report(sections=["tremor", "label"], output_dir="reports/")
         """
-        from eruption_forecast.report.pipeline_report import PipelineReport
-
         pipeline = PipelineReport.from_forecast_model(
             self, sections=sections, output_dir=output_dir
         )

--- a/src/eruption_forecast/model/model_predictor.py
+++ b/src/eruption_forecast/model/model_predictor.py
@@ -9,7 +9,9 @@ from eruption_forecast.config.constants import MATPLOTLIB_BACKEND
 from eruption_forecast.utils.formatting import slugify
 
 
-matplotlib.use(MATPLOTLIB_BACKEND)  # Must be called before pyplot import — non-interactive backend safe for worker threads
+matplotlib.use(
+    MATPLOTLIB_BACKEND
+)  # Must be called before pyplot import — non-interactive backend safe for worker threads
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -19,7 +21,7 @@ from eruption_forecast.logger import logger
 from eruption_forecast.utils.ml import load_labels_from_csv, compute_model_probabilities
 from eruption_forecast.utils.window import construct_windows
 from eruption_forecast.utils.pathutils import ensure_dir, resolve_output_dir
-from eruption_forecast.utils.date_utils import to_datetime
+from eruption_forecast.utils.date_utils import normalize_dates
 from eruption_forecast.tremor.tremor_data import TremorData
 from eruption_forecast.model.seed_ensemble import SeedEnsemble
 from eruption_forecast.model.model_evaluator import ModelEvaluator
@@ -184,10 +186,9 @@ class ModelPredictor:
         # ------------------------------------------------------------------
         # Set DEFAULT parameter
         # ------------------------------------------------------------------
-        start_date = to_datetime(start_date).replace(hour=0, minute=0, second=0)
-        end_date = to_datetime(end_date).replace(hour=23, minute=59, second=59)
-        start_date_str = start_date.strftime("%Y-%m-%d")
-        end_date_str = end_date.strftime("%Y-%m-%d")
+        start_date, end_date, start_date_str, end_date_str = normalize_dates(
+            start_date, end_date
+        )
 
         # Output training dir: ``<root_dir>/output/trainings``
         output_dir = resolve_output_dir(

--- a/src/eruption_forecast/sources/fdsn.py
+++ b/src/eruption_forecast/sources/fdsn.py
@@ -9,6 +9,7 @@ from eruption_forecast.logger import logger
 from eruption_forecast.sources.sds import SDS
 from eruption_forecast.sources.base import SeismicDataSource
 from eruption_forecast.utils.pathutils import ensure_dir
+from eruption_forecast.utils.date_utils import normalize_dates
 
 
 class FDSN(SeismicDataSource):
@@ -147,8 +148,7 @@ class FDSN(SeismicDataSource):
 
         prefix = self.SDS._make_log_prefix(date)
 
-        start_date = date.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_date = date.replace(hour=23, minute=59, second=59, microsecond=59)
+        start_date, end_date, _, _ = normalize_dates(date, date)
         start_date_utc = UTCDateTime(start_date)
         end_date_utc = UTCDateTime(end_date)
 
@@ -171,9 +171,7 @@ class FDSN(SeismicDataSource):
 
             if len(stream) == 0:
                 if self.verbose:
-                    logger.info(
-                        f"{prefix} Waveforms retrieved. No trace(s) found."
-                    )
+                    logger.info(f"{prefix} Waveforms retrieved. No trace(s) found.")
                 return Stream()
 
             if self.verbose:

--- a/src/eruption_forecast/tremor/calculate_tremor.py
+++ b/src/eruption_forecast/tremor/calculate_tremor.py
@@ -99,7 +99,7 @@ class CalculateTremor:
         remove_outlier_method (Literal["maximum", "all"]): Outlier removal strategy.
             "maximum" removes only the single maximum outlier; "all" removes all outliers.
             Defaults to "maximum".
-        remove_tremor_anomalies (bool, optional): Remove anomalies after tremor calciulated.
+        remove_tremor_anomalies (bool, optional): Remove anomalies after tremor calculated.
             Using Z-score analysis to determine the anomalies. Defaults to False.
         interpolate (bool): If True, interpolates gaps in the data. Defaults to False.
         value_multiplier (float | None): Scaling factor applied to seismic values.

--- a/src/eruption_forecast/utils/window.py
+++ b/src/eruption_forecast/utils/window.py
@@ -4,7 +4,6 @@ This module provides functions for creating time windows, extracting window
 information from seismic traces, and calculating window-based metrics for
 tremor analysis.
 """
-
 from typing import Literal
 from datetime import datetime, timedelta
 from collections.abc import Callable
@@ -23,6 +22,7 @@ from eruption_forecast.config.constants import (
     DEFAULT_WINDOW_DURATION_MINUTES,
     DEFAULT_MINIMUM_COMPLETION_RATIO,
 )
+from eruption_forecast.utils.date_utils import normalize_dates
 from eruption_forecast.utils.validation import (
     validate_date_ranges,
     validate_window_step,
@@ -364,8 +364,7 @@ def construct_windows(
             f"window_step: {window_step}, maximum_window_step: {maximum_window_step}"
         )
 
-    start_date = start_date.replace(hour=0, minute=0, second=0)
-    end_date = end_date.replace(hour=23, minute=59, second=59)
+    start_date, end_date, _, _ = normalize_dates(start_date, end_date)
 
     freq = (
         timedelta(minutes=window_step)

--- a/tests/test_forecast_model.py
+++ b/tests/test_forecast_model.py
@@ -26,8 +26,6 @@ def _valid_kwargs(output_dir: str) -> dict:
     return {
         "station": "OJN",
         "channel": "EHZ",
-        "start_date": "2020-01-01",
-        "end_date": "2020-01-10",
         "window_size": 1,
         "volcano_id": "VOLCANO_001",
         "network": "VG",
@@ -96,13 +94,11 @@ class TestForecastModelInit:
                 ForecastModel(**kwargs)
 
     def test_start_after_end_raises(self) -> None:
-        """ValueError when start_date is after end_date."""
+        """ValueError when start_date is after end_date (raised by calculate())."""
         with tempfile.TemporaryDirectory() as tmp:
-            kwargs = _valid_kwargs(tmp)
-            kwargs["start_date"] = "2020-06-01"
-            kwargs["end_date"] = "2020-01-01"
+            fm = ForecastModel(**_valid_kwargs(tmp))
             with pytest.raises(ValueError):
-                ForecastModel(**kwargs)
+                fm.calculate(start_date="2020-06-01", end_date="2020-01-01")
 
     def test_output_directories_created(self) -> None:
         """All three output directories exist after init."""


### PR DESCRIPTION
- Refactor ForecastModel to defer tremor date handling to calculate() instead of requiring start_date/end_date at construction.
- Constructor now requires network and location, initialises start/end related attributes as None, and removes early date normalization; 
- calculate() now normalises, validates and stores start/end and updates calculate config. 
- Added a static _label_builder factory to centralise label construction (dynamic vs standard) and simplified build_label to use it. 
- Strengthened validation (require non-empty network/location, n_jobs > 0) and added guards for None when comparing dates. 
- Minor fixes: move PipelineReport import to module scope, fix typos in messages/logging, improve type-safety and logging of start/end dates.