### PR TITLE
Fix notification raises an error when TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are empty

### DIFF
--- a/src/eruption_forecast/decorators/notify.py
+++ b/src/eruption_forecast/decorators/notify.py
@@ -311,12 +311,8 @@ def notify(
             and returns a list of paths. Defaults to None.
 
     Returns:
-        Callable: Decorator function that wraps the target function.
-
-    Raises:
-        ValueError: If ``bot_token`` or ``chat_id`` cannot be resolved from
-            arguments or environment variables at decoration time.
-        ValueError: If ``bot_token`` or ``chat_id`` contains whitespace.
+        Callable: Decorator function that wraps the target function, or a
+            no-op decorator if credentials are missing or invalid.
 
     Examples:
         >>> @notify(bot_token="TOKEN", chat_id="123", name="Training")
@@ -337,22 +333,30 @@ def notify(
     resolved_chat: str | int = chat_id or os.environ.get("TELEGRAM_CHAT_ID", "")
 
     if not resolved_token:
-        raise ValueError(
-            "notify: bot_token not provided and TELEGRAM_BOT_TOKEN not set in environment."
+        logger.warning(
+            "notify: bot_token not provided and TELEGRAM_BOT_TOKEN not set in environment. "
+            "Notifications disabled."
         )
+        return lambda func: func
     if any(c.isspace() for c in resolved_token):
-        raise ValueError(
+        logger.warning(
             f"notify: bot_token contains whitespace — got {resolved_token!r}. "
-            "Ensure TELEGRAM_BOT_TOKEN is set to the raw token from BotFather."
+            "Ensure TELEGRAM_BOT_TOKEN is set to the raw token from BotFather. "
+            "Notifications disabled."
         )
+        return lambda func: func
     if not resolved_chat:
-        raise ValueError(
-            "notify: chat_id not provided and TELEGRAM_CHAT_ID not set in environment."
+        logger.warning(
+            "notify: chat_id not provided and TELEGRAM_CHAT_ID not set in environment. "
+            "Notifications disabled."
         )
+        return lambda func: func
     if isinstance(resolved_chat, str) and any(c.isspace() for c in resolved_chat):
-        raise ValueError(
-            f"notify: chat_id contains whitespace — got {resolved_chat!r}."
+        logger.warning(
+            f"notify: chat_id contains whitespace — got {resolved_chat!r}. "
+            "Notifications disabled."
         )
+        return lambda func: func
 
     hostname = socket.gethostname()
 

--- a/src/eruption_forecast/decorators/notify.py
+++ b/src/eruption_forecast/decorators/notify.py
@@ -273,7 +273,7 @@ def notify(
     name: str | None = None,
     on_success: bool = True,
     on_error: bool = True,
-    timeout: float = 10.0,
+    timeout: float = 3.0,
     bot_token: str | None = None,
     chat_id: str | int | None = None,
     include_elapsed: bool = True,
@@ -298,7 +298,7 @@ def notify(
         on_error (bool): Whether to send a notification when an exception is
             raised. Defaults to True.
         timeout (float): Socket timeout in seconds passed to the Telegram HTTP
-            requests. Defaults to 10.0.
+            requests. Defaults to 3.0.
         bot_token (str | None): Telegram bot token. Falls back to the
             ``TELEGRAM_BOT_TOKEN`` environment variable. Defaults to None.
         chat_id (str | int | None): Telegram chat ID or username. Falls back
@@ -332,31 +332,38 @@ def notify(
     resolved_token: str = bot_token or os.environ.get("TELEGRAM_BOT_TOKEN", "")
     resolved_chat: str | int = chat_id or os.environ.get("TELEGRAM_CHAT_ID", "")
 
+    def _noop(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
     if not resolved_token:
         logger.warning(
             "notify: bot_token not provided and TELEGRAM_BOT_TOKEN not set in environment. "
             "Notifications disabled."
         )
-        return lambda func: func
-    if any(c.isspace() for c in resolved_token):
+        return _noop
+    if any(char.isspace() for char in resolved_token):
         logger.warning(
             f"notify: bot_token contains whitespace (length {len(resolved_token)}). "
             "Ensure TELEGRAM_BOT_TOKEN is set to the raw token from BotFather. "
             "Notifications disabled."
         )
-        return lambda func: func
+        return _noop
     if not resolved_chat:
         logger.warning(
             "notify: chat_id not provided and TELEGRAM_CHAT_ID not set in environment. "
             "Notifications disabled."
         )
-        return lambda func: func
-    if isinstance(resolved_chat, str) and any(c.isspace() for c in resolved_chat):
+        return _noop
+    if isinstance(resolved_chat, str) and any(char.isspace() for char in resolved_chat):
         logger.warning(
             f"notify: chat_id contains whitespace — got {resolved_chat!r}. "
             "Notifications disabled."
         )
-        return lambda func: func
+        return _noop
 
     hostname = socket.gethostname()
 
@@ -397,7 +404,9 @@ def notify(
                         elapsed if include_elapsed else None,
                     )
                     try:
-                        _send_telegram_message(resolved_token, resolved_chat, msg, timeout)
+                        _send_telegram_message(
+                            resolved_token, resolved_chat, msg, timeout
+                        )
                     except Exception as notify_exc:
                         logger.warning(
                             f"Failed to send error notification: {notify_exc}"

--- a/src/eruption_forecast/decorators/notify.py
+++ b/src/eruption_forecast/decorators/notify.py
@@ -340,7 +340,7 @@ def notify(
         return lambda func: func
     if any(c.isspace() for c in resolved_token):
         logger.warning(
-            f"notify: bot_token contains whitespace — got {resolved_token!r}. "
+            f"notify: bot_token contains whitespace (length {len(resolved_token)}). "
             "Ensure TELEGRAM_BOT_TOKEN is set to the raw token from BotFather. "
             "Notifications disabled."
         )

--- a/src/eruption_forecast/plots/forecast_plots.py
+++ b/src/eruption_forecast/plots/forecast_plots.py
@@ -245,7 +245,7 @@ def plot_forecast(
         bbox_to_anchor=(0.05, -0.075),
     )
 
-    plt.suptitle(title or "Forecast Results", fontsize=14)
+    fig.suptitle(title or "Forecast Results", fontsize=14)
     plt.tight_layout()
 
     return fig

--- a/src/eruption_forecast/plots/forecast_plots.py
+++ b/src/eruption_forecast/plots/forecast_plots.py
@@ -38,7 +38,7 @@ from eruption_forecast.utils.date_utils import (
 
 def plot_forecast(
     df: pd.DataFrame,
-    label_df: pd.DataFrame | pd.Series,
+    label_df: pd.DataFrame | pd.Series | None = None,
     title: str | None = None,
     fig_width: float = 12,
     fig_height: float = 3,
@@ -96,7 +96,12 @@ def plot_forecast(
         }
     )
 
-    if label_df is not None:
+    # Ensure df have pd.DatetimeIndex
+    if not isinstance(df.index, pd.DatetimeIndex):
+        if label_df is None or len(label_df) == 0:
+            raise ValueError(
+                "label_df is needed since concensus dataframe does not have pd.DatetimeIndex."
+            )
         df = set_datetime_index(label_df, df)
 
     # Maintain backward compatibility
@@ -253,7 +258,7 @@ def plot_forecast(
 
 def plot_forecast_from_file(
     consensus_file: str,
-    label_file: str,
+    label_file: str | None = None,
     title: str | None = None,
     fig_width: float = 12,
     fig_height: float = 3,
@@ -285,10 +290,12 @@ def plot_forecast_from_file(
     Returns:
         plt.Figure: Matplotlib figure object with three vertically stacked subplots.
     """
-    df = pd.read_csv(consensus_file, index_col="id")
-    label_df = pd.read_csv(label_file, index_col=0, parse_dates=True)
-
-    df = set_datetime_index(label_df, df)
+    df = pd.read_csv(consensus_file, index_col=0, parse_dates=True)
+    label_df = (
+        pd.read_csv(label_file, index_col=0, parse_dates=True)
+        if label_file
+        else pd.DataFrame()
+    )
 
     return plot_forecast(
         df,

--- a/src/eruption_forecast/plots/forecast_plots.py
+++ b/src/eruption_forecast/plots/forecast_plots.py
@@ -100,7 +100,8 @@ def plot_forecast(
     if not isinstance(df.index, pd.DatetimeIndex):
         if label_df is None or len(label_df) == 0:
             raise ValueError(
-                "label_df is needed since concensus dataframe does not have pd.DatetimeIndex."
+                "df must have a DatetimeIndex; provide label_df (id→datetime mapping) so "
+                "set_datetime_index() can construct and align the forecast index."
             )
         df = set_datetime_index(label_df, df)
 

--- a/src/eruption_forecast/plots/forecast_plots.py
+++ b/src/eruption_forecast/plots/forecast_plots.py
@@ -102,6 +102,7 @@ def plot_forecast(
             raise ValueError(
                 "df must have a DatetimeIndex; provide label_df (id→datetime mapping) so "
                 "set_datetime_index() can construct and align the forecast index."
+                "set_datetime_index() can construct and align the forecast index."
             )
         df = set_datetime_index(label_df, df)
 


### PR DESCRIPTION
- [x] Redact `resolved_token` from whitespace-validation warning log; now logs only the token length instead of the full credential